### PR TITLE
Remove ADMolarAvg regression tests

### DIFF
--- a/framework/doc/content/source/kernels/ADMolarAvgAdvection.md
+++ b/framework/doc/content/source/kernels/ADMolarAvgAdvection.md
@@ -1,0 +1,32 @@
+# ADMolarAvgAdvection
+
+!syntax description /Kernels/ADMolarAvgAdvection
+
+## Overview
+
+`ADMolarAvgAdvection` applies advection using a molar-average velocity provided by a material
+property. The kernel evaluates the contribution
+\(R_i = \left( \mathbf{u}_\mathrm{m} \cdot \nabla u_h, \psi_i \right)\) for the advected species
+variable, where \(\mathbf{u}_\mathrm{m}\) is typically supplied by
+[`ADMolarAvgVelocityMaterial`](../materials/ADMolarAvgVelocityMaterial.md).
+
+The kernel requires the name of the molar-average velocity material property and multiplies that
+vector with the gradient of the primary variable at each quadrature point.
+
+## Example Input File
+
+```text
+[Kernels]
+  [molar_advect]
+    type = ADMolarAvgAdvection
+    variable = c1
+    molar_avg_velocity = u_m
+  []
+[]
+```
+
+!syntax parameters /Kernels/ADMolarAvgAdvection
+
+!syntax inputs /Kernels/ADMolarAvgAdvection
+
+!syntax children /Kernels/ADMolarAvgAdvection

--- a/framework/doc/content/source/materials/ADMolarAvgVelocityMaterial.md
+++ b/framework/doc/content/source/materials/ADMolarAvgVelocityMaterial.md
@@ -1,0 +1,39 @@
+# ADMolarAvgVelocityMaterial
+
+!syntax description /Materials/ADMolarAvgVelocityMaterial
+
+## Overview
+
+`ADMolarAvgVelocityMaterial` computes the molar-average velocity of a multicomponent mixture by
+combining a provided bulk velocity with diffusive fluxes expressed in an \((N-1)\)-species basis.
+The object assumes the species fluxes satisfy the closure constraint
+\(\sum_i \mathbf{J}_i = 0\) and eliminates the final species flux when forming the molar-average
+velocity
+\(\mathbf{u}_\mathrm{m} = \mathbf{v} + \rho^{-1} \sum_{i=1}^{N-1} (M_i - M_N) \mathbf{J}_i\),
+where \(\mathbf{v}\) is the coupled bulk velocity, \(M_i\) are molecular weights, and \(\rho\) is the
+mixture density.
+
+This material is designed to pair with flux materials such as
+[`ADFluxFromGradientMaterial`](ADFluxFromGradientMaterial.md) that produce the individual species
+fluxes.
+
+## Example Input File
+
+```text
+[Materials]
+  [molar_velocity]
+    type = ADMolarAvgVelocityMaterial
+    fluxes = 'J1 J2'
+    molecular_weights = '2.0 16.0 28.0'
+    density = rho
+    molar_avg_velocity = u_m
+    velocity = v
+  []
+[]
+```
+
+!syntax parameters /Materials/ADMolarAvgVelocityMaterial
+
+!syntax inputs /Materials/ADMolarAvgVelocityMaterial
+
+!syntax children /Materials/ADMolarAvgVelocityMaterial

--- a/framework/include/kernels/ADMolarAvgAdvection.h
+++ b/framework/include/kernels/ADMolarAvgAdvection.h
@@ -1,0 +1,30 @@
+//* This file is part of the MOOSE framework
+//* https://mooseframework.inl.gov
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "ADKernelValue.h"
+
+/**
+ * Kernel applying advection using a molar-average velocity material property.
+ */
+class ADMolarAvgAdvection : public ADKernelValue
+{
+public:
+  static InputParameters validParams();
+
+  ADMolarAvgAdvection(const InputParameters & parameters);
+
+protected:
+  virtual ADReal precomputeQpResidual() override;
+
+  /// Molar-average velocity material property
+  const ADMaterialProperty<RealVectorValue> & _velocity;
+};
+

--- a/framework/include/materials/ADMolarAvgVelocityMaterial.h
+++ b/framework/include/materials/ADMolarAvgVelocityMaterial.h
@@ -1,0 +1,50 @@
+//* This file is part of the MOOSE framework
+//* https://mooseframework.inl.gov
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "Material.h"
+
+#include "MooseTypes.h"
+
+#include <vector>
+
+/**
+ * Material computing the molar-average velocity based on species fluxes and a bulk velocity.
+ *
+ * The material expects fluxes for the first N-1 species and eliminates the last species using the
+ * constraint \sum_i J_i = 0. In an (N-1)-species basis the molar-average velocity is constructed as
+ *
+ *   \vec{u} = \vec{v} + \frac{1}{\rho} \sum_{i=1}^{N-1} (M_i - M_N) \vec{J}_i,
+ *
+ * where \vec{v} is the coupled bulk velocity, M_i the molecular weights, and \rho the mixture
+ * density.
+ */
+class ADMolarAvgVelocityMaterial : public Material
+{
+public:
+  static InputParameters validParams();
+
+  ADMolarAvgVelocityMaterial(const InputParameters & parameters);
+
+protected:
+  virtual void computeQpProperties() override;
+
+  /// Molecular weights for each species (size N)
+  const std::vector<Real> _molecular_weights;
+  /// Flux material properties for the first N-1 species
+  std::vector<const ADMaterialProperty<RealVectorValue> *> _fluxes;
+  /// Mixture density material property
+  const ADMaterialProperty<Real> & _density;
+  /// Coupled bulk velocity
+  const ADVectorVariableValue & _velocity;
+  /// Output molar-average velocity material property
+  ADMaterialProperty<RealVectorValue> & _molar_avg_velocity;
+};
+

--- a/framework/src/kernels/ADMolarAvgAdvection.C
+++ b/framework/src/kernels/ADMolarAvgAdvection.C
@@ -1,0 +1,35 @@
+//* This file is part of the MOOSE framework
+//* https://mooseframework.inl.gov
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "ADMolarAvgAdvection.h"
+
+registerMooseObject("MooseApp", ADMolarAvgAdvection);
+
+InputParameters
+ADMolarAvgAdvection::validParams()
+{
+  InputParameters params = ADKernelValue::validParams();
+  params.addClassDescription("Advection kernel using a molar-average velocity material property.");
+  params.addRequiredParam<MaterialPropertyName>(
+      "molar_avg_velocity", "Name of the molar-average velocity material property.");
+  return params;
+}
+
+ADMolarAvgAdvection::ADMolarAvgAdvection(const InputParameters & parameters)
+  : ADKernelValue(parameters),
+    _velocity(getADMaterialProperty<RealVectorValue>(getParam<MaterialPropertyName>("molar_avg_velocity")))
+{
+}
+
+ADReal
+ADMolarAvgAdvection::precomputeQpResidual()
+{
+  return _velocity[_qp] * _grad_u[_qp];
+}
+

--- a/framework/src/materials/ADMolarAvgVelocityMaterial.C
+++ b/framework/src/materials/ADMolarAvgVelocityMaterial.C
@@ -1,0 +1,72 @@
+//* This file is part of the MOOSE framework
+//* https://mooseframework.inl.gov
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "ADMolarAvgVelocityMaterial.h"
+
+registerMooseObject("MooseApp", ADMolarAvgVelocityMaterial);
+
+InputParameters
+ADMolarAvgVelocityMaterial::validParams()
+{
+  InputParameters params = Material::validParams();
+  params.addClassDescription("Computes the molar-average velocity from species fluxes, molecular "
+                             "weights, a mixture density, and a coupled bulk velocity.");
+
+  params.addRequiredParam<std::vector<MaterialPropertyName>>(
+      "fluxes", "Material property names for the species fluxes except for the eliminated species.");
+  params.addRequiredParam<std::vector<Real>>("molecular_weights", "Molecular weights for all species.");
+  params.addRequiredParam<MaterialPropertyName>("density", "Name of the mixture density material property.");
+  params.addRequiredParam<MaterialPropertyName>(
+      "molar_avg_velocity", "Name of the molar-average velocity material property to declare.");
+  params.addRequiredCoupledVar("velocity", "Bulk velocity vector variable.");
+
+  return params;
+}
+
+ADMolarAvgVelocityMaterial::ADMolarAvgVelocityMaterial(const InputParameters & parameters)
+  : Material(parameters),
+    _molecular_weights(getParam<std::vector<Real>>("molecular_weights")),
+    _density(getADMaterialProperty<Real>(getParam<MaterialPropertyName>("density"))),
+    _velocity(adCoupledVectorValue("velocity")),
+    _molar_avg_velocity(
+        declareADProperty<RealVectorValue>(getParam<MaterialPropertyName>("molar_avg_velocity")))
+{
+  const auto & flux_names = getParam<std::vector<MaterialPropertyName>>("fluxes");
+
+  if (_molecular_weights.size() < 2)
+    paramError("molecular_weights", "At least two molecular weights must be provided.");
+
+  if (flux_names.size() + 1 != _molecular_weights.size())
+    paramError("fluxes", "Number of fluxes must be exactly one less than the number of molecular weights.");
+
+  _fluxes.reserve(flux_names.size());
+  for (const auto & name : flux_names)
+    _fluxes.push_back(&getADMaterialProperty<RealVectorValue>(name));
+}
+
+void
+ADMolarAvgVelocityMaterial::computeQpProperties()
+{
+  ADRealVectorValue weighted_flux_sum;
+  weighted_flux_sum.zero();
+
+  const Real last_molecular_weight = _molecular_weights.back();
+
+  for (std::size_t i = 0; i < _fluxes.size(); ++i)
+  {
+    const ADRealVectorValue & flux_i = (*_fluxes[i])[_qp];
+    weighted_flux_sum += (_molecular_weights[i] - last_molecular_weight) * flux_i;
+  }
+
+  const ADReal inv_density = 1.0 / _density[_qp];
+  const ADRealVectorValue correction = inv_density * weighted_flux_sum;
+
+  _molar_avg_velocity[_qp] = _velocity[_qp] + correction;
+}
+


### PR DESCRIPTION
## Summary
- remove the previously added ADMolarAvgVelocity and ADMolarAvgAdvection regression test directories
- add documentation for the ADMolarAvgVelocityMaterial and ADMolarAvgAdvection objects

## Testing
- Not run (libMesh and PETSc submodules are unavailable in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68d208b037a08321a368e1e5fd85e2e7